### PR TITLE
Fix for crash in Dart 2

### DIFF
--- a/lib/src/converter.dart
+++ b/lib/src/converter.dart
@@ -80,7 +80,7 @@ String _replacementForNode(Node node) {
 }
 
 Map<String, String> _getFlankingWhitespace(Node node) {
-  var result = {};
+  Map<String, String> result = {};
   if (!node.isBlock) {
     var hasLeading = new RegExp(r'^[ \r\n\t]').hasMatch(node.textContent);
     var hasTrailing = new RegExp(r'[ \r\n\t]$').hasMatch(node.textContent);


### PR DESCRIPTION
Converter currently crashes in Dart 2, because it fails to detect "result" variable as Map<String, String>, but it instead detects it as Map<dynamic, dynamic>.
This Exception is thrown:
type '_InternalLinkedHashMap<dynamic, dynamic>' is not a subtype of type 'Map<String, String>' where
   _InternalLinkedHashMap is from dart:collection
   Map is from dart:core
   String is from dart:core
   String is from dart:core