### PR TITLE
fix fenced codeBlockStyle problem when codeblock has no className

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -194,8 +194,8 @@ abstract class _Rules {
         node.firstChild.nodeName == 'code';
   }, replacement: (content, node) {
     var className = node.firstChild.className ?? '';
-    var language =
-        new RegExp(r'language-(\S+)').firstMatch(className).group(1) ?? '';
+    var languageMatched = new RegExp(r'language-(\S+)').firstMatch(className);
+    var language = languageMatched != null ? languageMatched.group(1) : className;
     return '\n\n' +
         getStyleOption('fence') +
         language +

--- a/test/html2md_test.dart
+++ b/test/html2md_test.dart
@@ -9,6 +9,7 @@ void main() {
     String optionsHtml;
     String removeHtml;
     String ignoreHtml;
+    String codeblockHtml;
 
     setUp(() {
       ignoreHtml = '''<!DOCTYPE html><head><script>console.log("test");</script></head><body>Hello</body>''';
@@ -44,6 +45,7 @@ void main() {
 </ul>
 <pre>defaultConfig{<br>...<br>minSdkVersion 15<br>...<br>}</pre>
 ''';
+      codeblockHtml = '''<pre><code>print('Hello, world');</code></pre>''';
     });
 
     test('Html Test', () {
@@ -102,6 +104,12 @@ minSdkVersion 15
 
     test('Ignore Test', () {
       expect(html2md.convert(ignoreHtml, ignore: ['script']), '''Hello''');
+    });
+
+    test('CodeBlock fenced Test', () {
+      expect(html2md.convert(codeblockHtml, styleOptions: {'codeBlockStyle': 'fenced'}), '''```
+print('Hello, world');
+```''');
     });
   });
 }


### PR DESCRIPTION
```html
<pre><code></code></pre>
```

```dart
    var language =
      new RegExp(r'language-(\S+)').firstMatch(className).group(1) ?? '';
```

`new RegExp(r'language-(\S+)').firstMatch(className)` is null. so fix it.
