### PR TITLE
Fix: don't escape MD if text is part of URL

### DIFF
--- a/lib/src/converter.dart
+++ b/lib/src/converter.dart
@@ -74,14 +74,15 @@ String _escape(String input) {
             .replaceAllMapped(RegExp(r'([*+-])'), (match) => '\\${match[1]}');
       })
       .replaceAllMapped(RegExp(r'^(\W* {0,3})> '), (match) => '${match[1]}\\> ')
-      .replaceAllMapped(RegExp(r'\*+(?![*\s\W]).+?\*+'),
+      .replaceAllMapped(RegExp(_notLink + r'\*+(?![*\s\W]).+?\*+'),
           (match) => match[0]!.replaceAll(RegExp(r'\*'), '\\*'))
-      .replaceAllMapped(RegExp(r'_+(?![_\s\W]).+?_+'),
+      .replaceAllMapped(RegExp(_notLink + r'_+(?![_\s\W]).+?_+'),
           (match) => match[0]!.replaceAll(RegExp(r'_'), '\\_'))
-      .replaceAllMapped(RegExp(r'`+(?![`\s\W]).+?`+'),
+      .replaceAllMapped(RegExp(_notLink + r'`+(?![`\s\W]).+?`+'),
           (match) => match[0]!.replaceAll(RegExp(r'`'), '\\`'))
-      .replaceAllMapped(RegExp(r'[\[\]]'), (match) => '\\${match[0]}');
+      .replaceAllMapped(RegExp(_notLink + r'[\[\]]'), (match) => '\\${match[0]}');
 }
+const _notLink = r'(?<!(https?://|mailto:|tel:)\S+)';
 
 Map<String, String> _getFlankingWhitespace(Node node) {
   var result = <String, String>{};

--- a/lib/src/converter.dart
+++ b/lib/src/converter.dart
@@ -75,11 +75,11 @@ String escape(String input) {
             .replaceAllMapped(RegExp(r'([*+-])'), (match) => '\\${match[1]}');
       })
       .replaceAllMapped(RegExp(r'^(\W* {0,3})> '), (match) => '${match[1]}\\> ')
-      .replaceAllMapped(RegExp(_notLink + r'\*+(?![*\s\W]).+?\*+'),
+      .replaceAllMapped(RegExp(_notLink + r'\*+(?!\s)[^*]+(?<!\s)\*+'), //space NOT allowed after the 1st *
           (match) => match[0]!.replaceAll(RegExp(r'\*'), '\\*'))
-      .replaceAllMapped(RegExp(_notLink + r'_+(?![_\s\W]).+?_+'),
+      .replaceAllMapped(RegExp(_notLink + r'_+(?!\s)[^_]+(?<!\s)_+'), //space NOT allowed after the 1st _
           (match) => match[0]!.replaceAll(RegExp(r'_'), '\\_'))
-      .replaceAllMapped(RegExp(_notLink + r'`+(?![`\s\W]).+?`+'),
+      .replaceAllMapped(RegExp(_notLink + r'`+[^`]+`+'), //space allowed after the 1st `
           (match) => match[0]!.replaceAll(RegExp(r'`'), '\\`'))
       .replaceAllMapped(RegExp(_notLink + r'[\[\]]'), (match) => '\\${match[0]}');
 }

--- a/lib/src/converter.dart
+++ b/lib/src/converter.dart
@@ -142,7 +142,7 @@ String _postProcess(String input) {
   if (input.isNotEmpty) {
     return input
         .replaceAll(RegExp(r'^[\t\r\n]+'), '')
-        .replaceAll(RegExp(r'[\t\r\n\s]+$'), '');
+        .replaceAll(RegExp(r'[\t\r\n]+$'), '');
   }
   return '';
 }

--- a/lib/src/converter.dart
+++ b/lib/src/converter.dart
@@ -58,7 +58,8 @@ String convert(
   return _postProcess(output);
 }
 
-String _escape(String input) {
+/// Escapes markdown's special characters to make it plain text.
+String escape(String input) {
   return input
       .replaceAllMapped(RegExp(r'\\(\S)'),
           (match) => '\\\\${match[1]}') // Escape backslash escapes!
@@ -151,7 +152,8 @@ String _process(Node inNode) {
     if (node.nodeType == 3) {
       // Text
       var textContent = node.textContent;
-      replacement = node.isCode ? textContent : _escape(textContent);
+      /// Escapes markdown's special characters to make it plain text.
+      replacement = node.isCode ? textContent : escape(textContent);
     } else if (node.nodeType == 1) {
       // Element
       replacement = _replacementForNode(node);

--- a/lib/src/converter.dart
+++ b/lib/src/converter.dart
@@ -81,6 +81,8 @@ String escape(String input) {
           (match) => match[0]!.replaceAll(RegExp(r'_'), '\\_'))
       .replaceAllMapped(RegExp(_notLink + r'`+[^`]+`+'), //space allowed after the 1st `
           (match) => match[0]!.replaceAll(RegExp(r'`'), '\\`'))
+      .replaceAllMapped(RegExp(_notLink + r'~+[^~]+~+'), //space allowed after the 1st ~
+          (match) => match[0]!.replaceAll(RegExp(r'~'), '\\~'))
       .replaceAllMapped(RegExp(_notLink + r'[\[\]]'), (match) => '\\${match[0]}');
 }
 const _notLink = r'(?<!(https?://|mailto:|tel:)\S+)';

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -168,8 +168,9 @@ dom.Node _collapseWhitespace(dom.Node domNode, List<String> removeTags) {
         continue;
       }
 
-      if (isBlock(elNode) || elNode.localName!.toLowerCase() == 'br') {
-        if (prevText != null) {
+      final nodeName = elNode.localName?.toLowerCase();
+      if (isBlock(elNode) || nodeName == 'br') {
+        if (prevText != null && nodeName != 'body') {
           prevText.data = prevText.data.replaceAll(RegExp(r' $'), '');
         }
         prevText = null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,9 +7,9 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  html: ^0.15.0
-  collection: ^1.15.0
+  html: any
+  collection: any
 
 dev_dependencies:
-  lints: ^1.0.1
-  test: ^1.16.5
+  lints: any
+  test: any

--- a/test/common_test.dart
+++ b/test/common_test.dart
@@ -179,5 +179,18 @@ print('你好, 世界');
       body?.innerHtml = 'Hello World';
       expect(html2md.convert(body!), '''Hello World''');
     });
+
+    test('MD pattern in URL', () {
+      final pattern = '12345psi5vvul-eF_0-oMYA_pHvAPM_M-',
+        ptnEscaped = r'12345psi5vvul-eF\_0-oMYA\_pHvAPM_M-',
+        path = 'https://drive.google.com/drive/folders/',
+        url = '$path$pattern';
+      expect(html2md.convert(url), url);
+      expect(html2md.convert(pattern), ptnEscaped); //still escape
+      expect(html2md.convert('$path $pattern'), '$path $ptnEscaped');
+
+      final email = 'mailto:joe_moon@foo_ab.com';
+      expect(html2md.convert(email), email);
+    });
   });
 }


### PR DESCRIPTION
As shown in the test case, `_escape()` may prefix `_` with `\` mistakely for URLs.
I adjusted the regular expression to ignore URLs.